### PR TITLE
SSIDs and passphrases with spaces and non-alphanumerical characters

### DIFF
--- a/run_config.lua
+++ b/run_config.lua
@@ -12,6 +12,16 @@ wifi.sta.getap(function(t)
 	end
 end)
 
+
+local unescape = function (s)
+	s = string.gsub(s, "+", " ")
+	s = string.gsub(s, "%%(%x%x)", function (h)
+			return string.char(tonumber(h, 16))
+		end)
+	return s
+end
+
+
 function setup_server(aps)
 	print("Setting up Wifi AP")
 	wifi.setmode(wifi.SOFTAP)
@@ -32,8 +42,8 @@ function setup_server(aps)
     	    end
         	local _GET = {}
         	if (vars ~= nil)then
-            	for k, v in string.gmatch(vars, "(%w+)=(%w+)&*") do
-                	_GET[k] = v
+            	for k, v in string.gmatch(vars, "(%w+)=([^%&]+)&*") do
+                	_GET[k] = unescape(v)
             	end
 	        end
               


### PR DESCRIPTION
Thanks for sharing this project - it is very useful!

I found a problem with SSIDs and passphrases that contain spaces and other non-alphanumerical characters so I have modified the code to handle those situations as well.

I can't find any restrictions to what characters can be used in an SSIDs in the 802.11 spec, so I have opened up for using any character. SSIDs are described in section 7.3.2.1 here:
http://standards.ieee.org/getieee802/download/802.11-2007.pdf

The unescape function is a snipplet from the LUA documentation http://www.lua.org/pil/20.3.html
