### PR TITLE
Config form in html file with variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bootloader for ESP8266 modules flashed with NodeMCU for simple wifi configuratio
 <img width='300' src='http://www.sebastian-hodapp.de/wp-content/uploads/images/espbootloader-comfortable-wifi-configuration/github_espbootloader.jpg'>
 
 # How does it work?
-The script checks whether there is already a wifi configured. If not, the configuration mode is started. You can force to boot in config mode even when there is a config file, by connecting GPIO3 to ground during the 5 seconds countdown at init.
+The script checks whether there is already a wifi configured. If not, the configuration mode is started. You can force to boot in config mode even when there is a config file, by connecting GPIO0 to ground anytime in the 5 seconds countdown at init.
 
 The ESP8266 provides an access point and webpage listing all available access points plus possibility to enter the wifi password and any other configuration parameters.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Bootloader for ESP8266 modules flashed with NodeMCU for simple wifi configuratio
 <img width='300' src='http://www.sebastian-hodapp.de/wp-content/uploads/images/espbootloader-comfortable-wifi-configuration/github_espbootloader.jpg'>
 
 # How does it work?
-The script checks whether there is already a wifi configured. If not, the configuration mode is started. The ESP8266 provides an access point and webpage listing all available access points plus possibility to enter the wifi password.
-These settings are stored persistently in the file *config.cl* and the module connects with to the network to run your normal code.
+The script checks whether there is already a wifi configured. If not, the configuration mode is started. You can force to boot in config mode even when there is a config file, by connecting GPIO3 to ground during the 5 seconds countdown at init.
+
+The ESP8266 provides an access point and webpage listing all available access points plus possibility to enter the wifi password and any other configuration parameters.
+
+These settings are stored persistently in the file *config.lc* and the module connects with to the network to run your normal code.
 
 # How to use it
-* Change variables *ssid* and *psw* in line 5 & 6 of the initialization script *init.lua* according to your needs. These are the credentials  to connect to the module in configuration mode.
+* Modify the *configform.html* file to include any configuration parameters that you need in your scripts.
 * Add your normal program routines to file *run_program.lua*
 * Upload all files to your ESP8266 module
 

--- a/configform.html
+++ b/configform.html
@@ -1,0 +1,11 @@
+<html><body>
+<form method='get' action='/'>
+Select access point: <select name='ssid'>${aps}</select><br>
+(or type hidden ssid): <input name='hiddenssid' value='${ssid}'/><br>
+Enter password: <input type='password' name='password'></input><br><br>
+
+MQTT Server: <input name='mqtt_server' value='${mqtt_server}'/><br>
+MQTT User  : <input name='mqtt_user' value='${mqtt_user}'/><br>
+MQTT Passwd: <input name='mqtt_passwd' value='${mqtt_passwd}'/><br>
+
+<button type='submit'>Save</button></form></body></html>

--- a/configform.html
+++ b/configform.html
@@ -1,12 +1,16 @@
 <html><body>
 <form method='get' action='/'>
-Select access point: <select name='ssid'>${aps}</select><br>
-(or type hidden ssid): <input name='hiddenssid' value='${ssid}'/><br>
-Enter password: <input type='password' name='password'></input><br><br>
+<table border='0'>
+<tr><td>Select access point: </td><td><select name='ssid'>${available_aps}</select></td></tr>
+<tr><td>(or type hidden ssid): </td><td><input name='hiddenssid' value='${ssid}'/></td></tr>
+<tr><td>Enter password: </td><td><input type='password' name='password'></input></td></tr>
 
-<!--sample configuration parameters-->
-MQTT Server: <input name='mqtt_server' value='${mqtt_server}'/><br>
-MQTT User  : <input name='mqtt_user' value='${mqtt_user}'/><br>
-MQTT Passwd: <input name='mqtt_passwd' value='${mqtt_passwd}'/><br>
+<!-- sample variables -->
+<tr><td>MQTT Server:</td><td> <input name='mqtt_server' value='${mqtt_server}'/></td></tr>
+<tr><td>MQTT User  :</td><td> <input name='mqtt_user' value='${mqtt_user}'/></td></tr>
+<tr><td>MQTT Passwd:</td><td> <input name='mqtt_passwd' value='${mqtt_passwd}'/></td></tr>
+<tr><td>MQTT Device ID:</td><td> <input name='mqtt_deviceid' value='${mqtt_deviceid}'/></td></tr>
 
-<button type='submit'>Save</button></form></body></html>
+<tr><td colspan=2><button type='submit'>Save</button></td></tr></table>
+
+</form></body></html>

--- a/configform.html
+++ b/configform.html
@@ -4,6 +4,7 @@ Select access point: <select name='ssid'>${aps}</select><br>
 (or type hidden ssid): <input name='hiddenssid' value='${ssid}'/><br>
 Enter password: <input type='password' name='password'></input><br><br>
 
+<!--sample configuration parameters-->
 MQTT Server: <input name='mqtt_server' value='${mqtt_server}'/><br>
 MQTT User  : <input name='mqtt_user' value='${mqtt_user}'/><br>
 MQTT Passwd: <input name='mqtt_passwd' value='${mqtt_passwd}'/><br>

--- a/init.lua
+++ b/init.lua
@@ -5,25 +5,20 @@
 ssid = "ESP8266"
 psw  = "espconfig"
 
-if pcall(function () 
-	dofile("config.lc")
-end) then
-	print("Connecting to WIFI...")
-	
-	wifi.setmode(wifi.STATION)
-	wifi.sta.config(ssid,password)
-	wifi.sta.connect()
+countdown = 5
 
-	tmr.alarm(1, 1000, 1, function() 
-		if wifi.sta.getip() == nil then
-			print("IP unavaiable, waiting.") 
-		else 
-			tmr.stop(1)
-			print("Connected, IP is "..wifi.sta.getip())
-			dofile("run_program.lua")
-		end 
-	end)
-else
-	print("Enter configuration mode")
-	dofile("run_config.lua")
-end
+tmr.alarm(0,1000,1,function()
+     print(countdown)
+     countdown = countdown -1 
+     if (countdown == 0) then
+          tmr.stop(0)
+          if pcall(function () 
+          	dofile("config.lc")
+          end) then
+               dofile("run_program.lua")
+          else
+          	print("Enter configuration mode")
+          	dofile("run_config.lua")
+          end
+     end
+end)

--- a/init.lua
+++ b/init.lua
@@ -1,9 +1,6 @@
 -- Copyright (c) 2015 Sebastian Hodapp
 -- https://github.com/sebastianhodapp/ESPbootloader
 
--- Change ssid and password of AP in configuration mode 
-ssid = "ESP8266"
-psw  = "espconfig"
 
 -- If GPIO0 changes during the countdown, launch config
 gpio.mode(3, gpio.INT)
@@ -12,7 +9,7 @@ gpio.trig(3,"both",function()
           dofile("run_config.lua")
      end)
      
-countdown = 5
+local countdown = 5
 
 tmr.alarm(0,1000,1,function()
      print(countdown)

--- a/init.lua
+++ b/init.lua
@@ -5,12 +5,20 @@
 ssid = "ESP8266"
 psw  = "espconfig"
 
+-- If GPIO0 changes during the countdown, launch config
+gpio.mode(3, gpio.INT)
+gpio.trig(3,"both",function()
+          tmr.stop(0)
+          dofile("run_config.lua")
+     end)
+     
 countdown = 5
 
 tmr.alarm(0,1000,1,function()
      print(countdown)
      countdown = countdown -1 
      if (countdown == 0) then
+          gpio.mode(3,gpio.FLOAT)
           tmr.stop(0)
           if pcall(function () 
           	dofile("config.lc")

--- a/run_config.lua
+++ b/run_config.lua
@@ -1,44 +1,59 @@
+-- compile this module if you have memory issues
 
 -- GPIO0 resets the module
 gpio.mode(3, gpio.INT)
 gpio.trig(3,"both",function()
           node.restart()
      end)
+     
 -- read previous config
 if file.open("config.lc") then
      file.close("config.lc")
      dofile("config.lc")
 end
 
--- function to interpret variables in strings
--- ssid="WLAN01"
--- str="my ssid is ${ssid}"
--- interp(str) -> "my ssid is WLAN01"
-function interp(s)
-  return (s:gsub('($%b{})', function(w) 
-          return _G[w:sub(3, -2)] or "" 
-     end))
+local unescape = function (s)
+     s = string.gsub(s, "+", " ")
+     s = string.gsub(s, "%%(%x%x)", function (h)
+          return string.char(tonumber(h, 16))
+         end)
+     return s
 end
-
 
 print("Get available APs")
 wifi.setmode(wifi.STATION) 
 wifi.sta.getap(function(t)
 	available_aps = "" 
 	if t then 
+          local count = 0
 		for k,v in pairs(t) do 
 			ap = string.format("%-10s",k) 
 			ap = trim(ap)
 			available_aps = available_aps .. "<option value='".. ap .."'>".. ap .."</option>"
+               count = count+1
+               if (count>=10) then break end
 		end 
-          available_aps = available_aps .. "<option value='-1'>--hidden--</option>"
-          setup_server(available_aps)
+          available_aps = available_aps .. "<option value='-1'>---hidden SSID---</option>"
+          setup_server()
 	end
 end)
 
+function setup_server()
 
+     -- Prepare HTML form
+     print("Preparing HTML Form")
+     if (file.open('configform.html','r')) then
+          buf = file.read()
+          file.close()
+     end
+     -- interpret variables in strings
+     -- ssid="WLAN01"
+     -- str="my ssid is ${ssid}"
+     -- interp(str) -> "my ssid is WLAN01"
+     buf = buf:gsub('($%b{})', function(w) 
+               return _G[w:sub(3, -2)] or "" 
+          end)
 
-function setup_server(aps)
 	print("Setting up Wifi AP")
      wifi.setmode(wifi.SOFTAP)
 	local cfg={}
@@ -51,15 +66,14 @@ function setup_server(aps)
 	srv=net.createServer(net.TCP)
 	srv:listen(80,function(conn)
     	conn:on("receive", function(client,request)
-        	local buf = "";
         	local _, _, method, path, vars = string.find(request, "([A-Z]+) (.+)?(.+) HTTP");
         	if(method == nil)then
 	            _, _, method, path = string.find(request, "([A-Z]+) (.+) HTTP");
     	     end
         	local _GET = {}
         	if (vars ~= nil)then
-            	for k, v in string.gmatch(vars, "([_%w]+)=([^&]+)&*") do
-                	_GET[k] = v
+            	for k, v in string.gmatch(vars, "([_%w]+)=([^%&]+)&*") do
+                	_GET[k] = unescape(v)
             	end
 	        end
               
@@ -77,24 +91,16 @@ function setup_server(aps)
     			node.compile("config.lua")
     			file.remove("config.lua")
     			client:send(buf);
-				node.restart();
+		     node.restart();
         	end
-    
-          if (file.open('configform.html','r')) then
-               -- make aps variable global to use in interp
-               _G.aps=aps
-               buf = interp(file.read())
-               file.close()
-          end
-	     
+
           payloadLen = string.len(buf)
           client:send("HTTP/1.1 200 OK\r\n")
           client:send("Content-Type    text/html; charset=UTF-8\r\n")
             
           client:send("Content-Length:" .. tostring(payloadLen) .. "\r\n")
           client:send("Connection:close\r\n\r\n")               
-    	     client:send(buf);
-        	client:close();
+          client:send(buf, function(client) client:close() end);
           end)
 	end)
 	print("Setting up Webserver done. Please connect to: " .. wifi.ap.getip())

--- a/run_config.lua
+++ b/run_config.lua
@@ -8,7 +8,7 @@ wifi.sta.getap(function(t)
 			ap = trim(ap)
 			available_aps = available_aps .. "<option value='".. ap .."'>".. ap .."</option>"
 		end 
-		setup_server(available_aps)
+          setup_server(available_aps)
 	end
 end)
 
@@ -16,8 +16,8 @@ function setup_server(aps)
 	print("Setting up Wifi AP")
 	wifi.setmode(wifi.SOFTAP)
 	cfg={}
-	cfg.ssid = ssid
-	cfg.pwd  = psw
+	cfg.ssid = "ESP8266config"
+	cfg.pwd  = ""
 	wifi.ap.config(cfg)
 
 	print("Setting up webserver")
@@ -42,6 +42,7 @@ function setup_server(aps)
         		file.open("config.lua", "w")
 				file.writeline('ssid = "' .. _GET.ap .. '"')
 				file.writeline('password = "' .. _GET.psw .. '"')
+                    file.writeline('thingspeak_apikey = "' .._GET.apikey ..'"')
     			file.close()
     			node.compile("config.lua")
     			file.remove("config.lua")
@@ -51,13 +52,20 @@ function setup_server(aps)
     
         	buf = "<html><body>"
         	buf = buf .. "<form method='get' action='http://" .. wifi.ap.getip() .."'>"
-	      	buf = buf .. "Select access point: <select name='ap'>" .. aps .. "</select><br>"
+               buf = buf .. "ThingSpeak API Key: <input type='text' name='apikey'></input><br><br>"
+               buf = buf .. "Select access point: <select name='ap'>" .. aps .. "</select><br>"
 	      	buf = buf .. "Enter password: <input type='password' name='psw'></input><br><br><button type='submit'>Save</button></form>"
 	      	buf = buf .. "</body></html>" 
-    	    client:send(buf);
+          payloadLen = string.len(buf)
+          client:send("HTTP/1.1 200 OK\r\n")
+          client:send("Content-Type    text/html; charset=UTF-8\r\n")
+            
+          client:send("Content-Length:" .. tostring(payloadLen) .. "\r\n")
+          client:send("Connection:close\r\n\r\n")               
+    	     client:send(buf);
         	client:close();
-	        collectgarbage();
-    	end)
+	     collectgarbage();
+          end)
 	end)
 	print("Setting up Webserver done. Please connect to: " .. wifi.ap.getip())
 end

--- a/run_program.lua
+++ b/run_program.lua
@@ -1,2 +1,8 @@
 -- Start your normal program routines here 
 print("Execute code")
+dofile("config.lc")
+wifi.setmode(wifi.STATION)
+wifi.sta.config(ssid,password)
+wifi.sta.connect()
+
+dofile("program.lc")

--- a/run_program.lua
+++ b/run_program.lua
@@ -5,4 +5,7 @@ wifi.setmode(wifi.STATION)
 wifi.sta.config(ssid,password)
 wifi.sta.connect()
 
-dofile("program.lc")
+ssid=nil
+password=nil
+
+dofile("mqtt-client.lc")


### PR DESCRIPTION
- config form moved to an independent .html file. You can add personalized variables in the file. (see configform.html for an example)
- countdown to stop init (just send a tmr.stop(0))

if you connect a pushbutton between GPIO0 and ground, you may:
- set GPIO0 to ground (push button) to force init to run run_config even when config.lc exists
- set GPIO0 to ground (push button) while in config mode to restart
